### PR TITLE
WEB-2433: Update security issue with lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -493,7 +493,7 @@
                         "string-width": "^4.2.0",
                         "which-module": "^2.0.0",
                         "y18n": "^4.0.0",
-                        "yargs-parser": "^18.1.1"
+                        "yargs-parser": "^18.1.0"
                     }
                 },
                 "yargs-parser": {
@@ -6071,7 +6071,7 @@
             "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
             "dev": true,
             "requires": {
-                "http-proxy": "^1.18.1",
+                "http-proxy": "^1.17.0",
                 "is-glob": "^4.0.0",
                 "lodash": "^4.17.11",
                 "micromatch": "^3.1.10"
@@ -7597,10 +7597,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash.clonedeep": {
             "version": "4.5.0",


### PR DESCRIPTION
* update lodash from 4.17.20 to 4.17.21 in response to CVE-20212337
* there was no depandabot alert for this!